### PR TITLE
chore: add deprecation notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+⛔️ DEPRECATED: peer-info is not used anymore in favour of storing this data in the [PeerStore](https://github.com/libp2p/js-libp2p/tree/master/src/peer-store)
+======
+
 # js-peer-info
 
 [![](https://img.shields.io/badge/made%20by-Protocol%20Labs-blue.svg?style=flat-square)](http://protocol.ai)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-⛔️ DEPRECATED: peer-info is not used anymore in favour of storing this data in the [PeerStore](https://github.com/libp2p/js-libp2p/tree/master/src/peer-store)
+⛔️ DEPRECATED: peer-info is not used anymore in favour of storing this data in the [PeerStore](https://github.com/libp2p/js-libp2p/tree/master/src/peer-store) from [libp2p@0.28.0](https://github.com/libp2p/js-libp2p/releases/tag/v0.28.0).
 ======
 
 # js-peer-info


### PR DESCRIPTION
In the context of https://github.com/libp2p/js-libp2p/issues/453 and https://github.com/libp2p/js-libp2p/issues/589, a deprecation notice is added.

Needs:

- [x]  npm deprecation notice

After merged, the repo must be archived